### PR TITLE
Update getZone to use grid size

### DIFF
--- a/dorianUniverse.js
+++ b/dorianUniverse.js
@@ -14,7 +14,7 @@ class Cell {
   }
 
   evaluate(neighbors, universe) {
-    const zone = getZone(this.x, this.y);
+    const zone = getZone(this.x, this.y, universe.cols, universe.rows);
     const { decay_modifier: mod, boost, suppress } = terrainZones[zone];
     // --- Emotion-to-zone preference mapping ---
     const emotionZonePreference = {

--- a/dorianUniverseOptimized.js
+++ b/dorianUniverseOptimized.js
@@ -83,7 +83,7 @@ export class DorianUniverseOptimized {
     const toUpdate = Array.from(this.active);
     for (const idx of toUpdate) {
       const [x, y] = this.coords(idx);
-      const zone = getZone(x, y);
+      const zone = getZone(x, y, this.cols, this.rows);
       const { decay_modifier: mod, boost, suppress } = terrainZones[zone];
       const neighbors = this.neighborMap[idx];
       const liveNeighbors = neighbors.filter(nidx => this.state[nidx]);

--- a/emotions.js
+++ b/emotions.js
@@ -26,8 +26,8 @@ export const terrainZones = {
 };
 
 // Return the terrain type based on coordinates (symbolic, not literal geography)
-export function getZone(x, y) {
-  const px = (x / 200), py = (y / 200);
+export function getZone(x, y, cols = 200, rows = 200) {
+  const px = (x / cols), py = (y / rows);
   if (px < 0.3 && py < 0.3) return 'mountain';
   if (px > 0.7 && py < 0.3) return 'desert';
   if (px < 0.3 && py > 0.7) return 'ocean';


### PR DESCRIPTION
## Summary
- make `getZone` accept grid dimensions
- pass column/row counts when calculating zones

## Testing
- `node -e "require('./dorianUniverse.js'); require('./dorianUniverseOptimized.js'); require('./emotions.js'); console.log('loaded');"`


------
https://chatgpt.com/codex/tasks/task_e_6844b7de7a9c8320863d50bd717bd6e9