### PR TITLE
Enhance speed slider UX

### DIFF
--- a/dorian.js
+++ b/dorian.js
@@ -11,7 +11,7 @@ const ROWS = 200;
 const MAX_AGE = 800;
 const MUTATION_CHANCE = 0.002;
 const BIRTH_DELAY = 5; // minimum dead ticks before a cell can grow again
-let UPDATES_PER_FRAME = 10;
+let UPDATES_PER_FRAME = 5;
 
 let running = true;
 let hasStarted = false;
@@ -99,13 +99,13 @@ mutationToggle.addEventListener('change', () => {
   }
 });
 
-speedSlider.max = '10';
+speedSlider.max = '5';
 speedSlider.addEventListener('input', () => {
-  if (parseInt(speedSlider.value) > 10) speedSlider.value = '10';
+  if (parseInt(speedSlider.value) > 5) speedSlider.value = '5';
   UPDATES_PER_FRAME = parseInt(speedSlider.value);
   speedValue.textContent = speedSlider.value;
 });
-if (parseInt(speedSlider.value) > 10) speedSlider.value = '10';
+if (parseInt(speedSlider.value) > 5) speedSlider.value = '5';
 UPDATES_PER_FRAME = parseInt(speedSlider.value);
 speedValue.textContent = speedSlider.value;
 

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
           <div class="speed-slider-wrapper">
             <label for="speed-slider">Speed:</label>
             
-            <input type="range" id="speed-slider" min="1" max="10" value="1" class="speed-slider">
+            <input type="range" id="speed-slider" min="1" max="5" value="1" step="1" class="speed-slider">
             <span>x <span id="speed-value">1</span></span>
           </div>
           <div class="ui-speed-btns">

--- a/style.css
+++ b/style.css
@@ -327,13 +327,14 @@ canvas[class^="dominant-emotion"] {
   appearance: none;
   height: 6px;
   border-radius: 3px;
-  background: linear-gradient(to right, #888 0%, #444 100%);
+  background: linear-gradient(to right, #444 0%, #222 100%);
   transition: background 0.3s ease;
   cursor: pointer;
+  outline: none;
 }
 
 .speed-slider:hover {
-  background: linear-gradient(to right, #aaa 0%, #666 100%);
+  background: linear-gradient(to right, #666 0%, #333 100%);
 }
 
 .speed-slider::-webkit-slider-thumb,
@@ -341,8 +342,8 @@ canvas[class^="dominant-emotion"] {
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  background: #ccc;
-  border: 2px solid #222;
+  background: #666;
+  border: 2px solid #000;
   box-shadow: 0 0 4px rgba(255, 255, 255, 0.3);
   transition: transform 0.2s ease, background 0.2s ease;
 }
@@ -350,7 +351,7 @@ canvas[class^="dominant-emotion"] {
 .speed-slider:hover::-webkit-slider-thumb,
 .speed-slider:hover::-moz-range-thumb {
   transform: scale(1.2);
-  background: #fff;
+  background: #999;
 }
 
 /* === Buttons === */


### PR DESCRIPTION
## Summary
- cut the speed slider range in half
- darken slider styling and smooth transitions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849a730dcc08320bc6d4ae91a00d7a7