### PR TITLE
Implement gpt helper and refactor stats fetch

### DIFF
--- a/dorian.js
+++ b/dorian.js
@@ -1,3 +1,5 @@
+import { sendPrompt } from './gptIntegration.js';
+
 const CELL_SIZE = 5; // px per cell
 
 // Fixed canvas size
@@ -41,15 +43,9 @@ Choose the most appropriate dominant emotion **from this exact list**:
 `;
 
   try {
-    const res = await fetch('http://localhost:3000/ask', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ prompt })
-    });
-
-    const data = await res.json();
-    console.log("Claude raw reply:", data.reply);
-    return data.reply?.toLowerCase().trim();
+    const reply = await sendPrompt(prompt);
+    console.log("Claude raw reply:", reply);
+    return reply?.toLowerCase().trim();
   } catch (err) {
     console.error("Claude error:", err);
     return null;

--- a/gptIntegration.js
+++ b/gptIntegration.js
@@ -1,0 +1,14 @@
+export async function sendPrompt(prompt) {
+  try {
+    const res = await fetch('http://localhost:3000/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt })
+    });
+    const data = await res.json();
+    return data.reply;
+  } catch (err) {
+    console.error('GPT integration error:', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `sendPrompt` helper in `gptIntegration.js`
- use `sendPrompt` in `sendStatsToClaude` for centralized Claude requests

## Testing
- `node --check dorian.js`
- `node --check gptIntegration.js`


------
https://chatgpt.com/codex/tasks/task_e_684a6d5db34483208425204b7d46945c