### PR TITLE
Simplify seed/start logic

### DIFF
--- a/dorian.js
+++ b/dorian.js
@@ -197,29 +197,22 @@ worker.onmessage = ({ data }) => {
 
 
 
-let hasSeeded = false;
-
 canvas.addEventListener('mousedown', (e) => {
   const rect = canvas.getBoundingClientRect();
   const x = Math.floor((e.clientX - rect.left) / CELL_SIZE);
   const y = Math.floor((e.clientY - rect.top) / CELL_SIZE);
 
-  // Always allow seeding when simulation is running
-worker.postMessage({ type: 'seed', x, y });
-
-if (!hasStarted) {
-  hasStarted = true;
-  running = true;
-  animate();
-}
-
+  // Seed the clicked cell
+  worker.postMessage({ type: 'seed', x, y });
 
   if (!hasStarted) {
-    worker.postMessage({ type: 'seed', x, y });
     hasStarted = true;
     running = true;
     animate();
-  } else {
+    return;
+  }
+
+  if (!running) {
     // Optional: feedback if paused
     canvas.classList.add('seed-denied');
     setTimeout(() => canvas.classList.remove('seed-denied'), 500);


### PR DESCRIPTION
## Summary
- remove unused `hasSeeded` variable
- simplify canvas `mousedown` handler
- ensure seeding occurs exactly once per click while still starting the simulation on the first click

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a6d5f5ff08320a1b7a2824d5cc4b9