### PR TITLE
Add agent count and reproduction controls

### DIFF
--- a/dorian.js
+++ b/dorian.js
@@ -69,22 +69,47 @@ function initWorker() {
       if (running) requestAnimationFrame(animate);
     }
   };
-  worker.postMessage({ type: 'init', opts: { cols: COLS, rows: ROWS, maxAge: MAX_AGE, mutationChance: MUTATION_CHANCE, birthDelay: BIRTH_DELAY, cellSize: CELL_SIZE } });
+  worker.postMessage({
+    type: 'init',
+    opts: {
+      cols: COLS,
+      rows: ROWS,
+      maxAge: MAX_AGE,
+      mutationChance: MUTATION_CHANCE,
+      birthDelay: BIRTH_DELAY,
+      cellSize: CELL_SIZE,
+      agentCount: parseInt(agentCountSlider.value),
+      reproductionRate: parseFloat(reproductionRateSlider.value)
+    }
+  });
 }
 
-initWorker();
-
-
+const agentCountSlider = document.getElementById('agent-count-slider');
+const reproductionRateSlider = document.getElementById('reproduction-rate-slider');
 const speedSlider = document.getElementById('speed-slider');
 const speedValue = document.getElementById('speed-value');
 const pauseBtn = document.getElementById('pause-btn');
 const mutationToggle = document.getElementById('toggle-mutation');
 const resetBtn = document.getElementById('reset-btn');
 
+initWorker();
+
 mutationToggle.addEventListener('change', () => {
   const chance = mutationToggle.checked ? MUTATION_CHANCE : 0;
   if (worker) {
     worker.postMessage({ type: 'setMutation', mutationChance: chance });
+  }
+});
+
+agentCountSlider.addEventListener('input', () => {
+  if (worker) {
+    worker.postMessage({ type: 'setAgentCount', count: parseInt(agentCountSlider.value) });
+  }
+});
+
+reproductionRateSlider.addEventListener('input', () => {
+  if (worker) {
+    worker.postMessage({ type: 'setReproductionRate', rate: parseFloat(reproductionRateSlider.value) });
   }
 });
 

--- a/dorianUniverseOptimized.js
+++ b/dorianUniverseOptimized.js
@@ -1,12 +1,14 @@
 import { EMOTIONS, EMOTION_LIST, EMOTION_ID_TO_NAME, getZone, terrainZones } from './emotions.js';
 
 export class DorianUniverseOptimized {
-  constructor({ 
-  cols, 
-  rows, 
-  maxAge, 
-  mutationChance, 
-  birthDelay 
+  constructor({
+  cols,
+  rows,
+  maxAge,
+  mutationChance,
+  birthDelay,
+  agentCount,
+  reproductionRate
 } = {}) {
   this.cols = cols !== undefined ? cols : 150 + Math.floor(Math.random() * 101); // 150-250
   this.rows = rows !== undefined ? rows : 150 + Math.floor(Math.random() * 101); // 150-250
@@ -14,6 +16,8 @@ export class DorianUniverseOptimized {
   this.maxAge = maxAge !== undefined ? maxAge : 1000 + Math.floor(Math.random() * 2001); // 1000-3000
   this.mutationChance = mutationChance !== undefined ? mutationChance : 0.01 + Math.random() * 0.09; // 0.01-0.10
   this.birthDelay = birthDelay !== undefined ? birthDelay : 1 + Math.floor(Math.random() * 5); // 1-5
+  this.agentCount = agentCount !== undefined ? agentCount : 500;
+  this.reproductionRate = reproductionRate !== undefined ? reproductionRate : 0.5;
 
     this.lifeForce = new Float32Array(this.size);
     this.emotion = new Uint8Array(this.size);
@@ -89,23 +93,25 @@ export class DorianUniverseOptimized {
     const emotion = this.randomEmotion();
     this.groupMeta.set(group, {
       dominantEmotion: emotion,
-      spreadRate: 0.0001 + Math.random() * 0.05,
+      spreadRate: (0.0001 + Math.random() * 0.05) * this.reproductionRate,
       aggression: Math.random(),
       mutationBias: Math.random()
     });
-    for (let dx = -1; dx <= 1; dx++) {
-      for (let dy = -1; dy <= 1; dy++) {
-        const x = cx + dx, y = cy + dy;
-        if (x >= 0 && y >= 0 && x < this.cols && y < this.rows) {
-          const idx = this.index(x, y);
-          this.lifeForce[idx] = 0.5 + Math.random() * 0.5; // Initial life force
-          this.emotion[idx] = emotion;
-          this.intensity[idx] = 1.0;
-          this.energy[idx] = 300;
-          this.age[idx] = 0;
-          this.groupId[idx] = group;
-          this.active.add(idx);
-        }
+
+    const radius = Math.max(1, Math.floor(Math.sqrt(this.agentCount) / 2));
+    for (let i = 0; i < this.agentCount; i++) {
+      const dx = Math.floor(Math.random() * (radius * 2 + 1)) - radius;
+      const dy = Math.floor(Math.random() * (radius * 2 + 1)) - radius;
+      const x = cx + dx, y = cy + dy;
+      if (x >= 0 && y >= 0 && x < this.cols && y < this.rows) {
+        const idx = this.index(x, y);
+        this.lifeForce[idx] = 0.5 + Math.random() * 0.5;
+        this.emotion[idx] = emotion;
+        this.intensity[idx] = 1.0;
+        this.energy[idx] = 300;
+        this.age[idx] = 0;
+        this.groupId[idx] = group;
+        this.active.add(idx);
       }
     }
   }
@@ -272,5 +278,17 @@ for (const n of neighbors) {
       }
     }
     return imageData;
+  }
+
+  setAgentCount(count) {
+    this.agentCount = count;
+  }
+
+  setReproductionRate(rate) {
+    this.reproductionRate = rate;
+  }
+
+  setMutationChance(chance) {
+    this.mutationChance = chance;
   }
 }

--- a/worker.js
+++ b/worker.js
@@ -33,11 +33,17 @@ function startAnimationLoop() {
 }
 
 self.onmessage = (e) => {
-  const { type, opts, x, y, updates, mutationChance } = e.data;
+  const { type, opts, x, y, updates, mutationChance, count, rate } = e.data;
   switch (type) {
     case 'init':
       universe = new DorianUniverseOptimized(opts);
       cellSize = opts.cellSize || cellSize;
+      if (typeof opts.agentCount === 'number') {
+        universe.setAgentCount(opts.agentCount);
+      }
+      if (typeof opts.reproductionRate === 'number') {
+        universe.setReproductionRate(opts.reproductionRate);
+      }
       break;
     case 'seed':
       if (universe) universe.seed(x, y);
@@ -56,6 +62,16 @@ self.onmessage = (e) => {
     case 'setMutation':
       if (universe && typeof mutationChance === 'number') {
         universe.setMutationChance(mutationChance);
+      }
+      break;
+    case 'setAgentCount':
+      if (universe && typeof count === 'number') {
+        universe.setAgentCount(count);
+      }
+      break;
+    case 'setReproductionRate':
+      if (universe && typeof rate === 'number') {
+        universe.setReproductionRate(rate);
       }
       break;
   }


### PR DESCRIPTION
## Summary
- control agent count and reproduction rate from UI
- notify worker about agent count and reproduction rate changes
- update worker to forward new settings to the simulation
- extend optimized universe with seed count and reproduction controls

## Testing
- `node --check dorian.js`
- `node --check worker.js`
- `node --check dorianUniverseOptimized.js`


------
https://chatgpt.com/codex/tasks/task_e_684a6d5fd8488320ae3aa11925173a22