### PR TITLE
Make API endpoint configurable

### DIFF
--- a/gptIntegration.js
+++ b/gptIntegration.js
@@ -1,11 +1,16 @@
 //FRONTEND
 // This file handles the integration with the GPT API for sending prompts and receiving responses.
 
+// Configurable API endpoint. Can be injected via <script> or process.env for Node
+const API_URL = (typeof window !== 'undefined' && window.API_URL) ||
+  (typeof process !== 'undefined' && process.env.API_URL) ||
+  'https://dorianjs.onrender.com';
+
 export async function sendUserPrompt(userInput) {
-  return await sendPrompt(userInput, false);
+  return await sendPrompt(userInput);
 }
 export async function sendAutoReflection(systemInput) {
-  return await sendPrompt(systemInput, true);
+  return await sendPrompt(systemInput);
 }
 console.log("🟢 LLM API ONLINE...");
 
@@ -39,7 +44,7 @@ ${userInput}`;
 
 
 try {
-    const res = await fetch("https://dorianjs.onrender.com/ask", {
+    const res = await fetch(`${API_URL}/ask`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ prompt: fullPrompt }),

--- a/index.html
+++ b/index.html
@@ -27,6 +27,11 @@
     href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap"
     rel="stylesheet">
 
+  <!-- Configuration -->
+  <script>
+    window.API_URL = 'https://dorianjs.onrender.com';
+  </script>
+
   <!-- JavaScript -->
   <script type="module" src="dorian.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- let API endpoint be provided via `window.API_URL` or environment variable
- remove unused boolean argument from prompt helpers
- inject the default API URL in `index.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685708fe34288320a64de3165b4160e9