### PR TITLE
Fix misplaced health check endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,6 +37,11 @@ app.get('/memory', (req, res) => {
 // Add static file serving for your frontend
 app.use(express.static('.')); // Serve your HTML/CSS/JS files
 
+// Health-check endpoint
+app.get('/healthz', (req, res) => {
+  res.send('OK');
+});
+
 
 // Consistent response parsing for both agents
 const parseResponse = (response) => {
@@ -85,10 +90,6 @@ app.post('/ask', async (req, res) => {
     tick: memory.meta.currentTick,
     reflection: reply,
      
-});
-
-app.get('/healthz', (req, res) => {
-  res.send('OK');
 });
 
 


### PR DESCRIPTION
## Summary
- expose `GET /healthz` once near app setup
- remove stray `/healthz` definition from inside `/ask` route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685708fcb9dc8320b218822b57e8b707