### PR TITLE
Update CORS to allow Render deployment

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,7 +17,8 @@ const PORT = process.env.PORT || 8080;
 const allowedOrigins = [
   'https://www.aidorian.com',                    //  custom domain
   'https://leafy-centaur-370c2f.netlify.app',  //  Netlify deploy preview
-  'http://localhost:3000'                      //  local dev (optional)
+  'http://localhost:3000',                     //  local dev (optional)
+  'https://dorianjs.onrender.com'              //  Render deployment
 ];
 
 app.use(


### PR DESCRIPTION
## Summary
- add Render deployment URL to the list of allowed CORS origins

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857172b3284832081214fa6e2e5e64b