### PR TITLE
Fix auto scroll to canvas

### DIFF
--- a/dorian.js
+++ b/dorian.js
@@ -13,6 +13,13 @@ let canvas, ctx;
 
 //DOM CONTENT LOADED ENSURES ALL DOM ELEMENTS HAVE BEEN LOADED
 window.addEventListener("DOMContentLoaded", () => {
+  // Prevent the browser from restoring the previous scroll position
+  if ("scrollRestoration" in history) {
+    history.scrollRestoration = "manual";
+  }
+
+  // Ensure the page always loads at the top
+  window.scrollTo(0, 0);
   const CELL_SIZE = 5; // px per cell
 
   let running = true;
@@ -189,6 +196,14 @@ function startChat() {
 
       startChat();
     });
+
+    // BotUI automatically focuses the input which can cause unwanted scrolling
+    setTimeout(() => {
+      if (document.activeElement) {
+        document.activeElement.blur();
+      }
+      window.scrollTo(0, 0);
+    }, 0);
   }
 
   startChat();


### PR DESCRIPTION
## Summary
- stop the browser from remembering scroll on reload
- scroll to the top after BotUI draws its input field

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68578b160da08320a00ae767037e6ab0